### PR TITLE
fix(dagger): Generated build fails

### DIFF
--- a/injection/build.gradle
+++ b/injection/build.gradle
@@ -45,8 +45,6 @@ android {
         abortOnError false
         ignoreWarnings true
     }
-
-    buildToolsVersion '26.0.2'
 }
 
 dependencies {

--- a/mobile-ui/build.gradle
+++ b/mobile-ui/build.gradle
@@ -4,11 +4,18 @@ apply plugin: 'kotlin-android-extensions'
 apply plugin: 'kotlin-kapt'
 apply plugin: 'jacoco-android'
 
+allprojects {
+    afterEvaluate {
+        tasks.withType(JavaCompile.class) {
+            options.compilerArgs << "-Xmaxerrs" << "500"
+        }
+    }
+}
+
 android {
     def globalConfiguration = rootProject.extensions.getByName("ext")
 
     compileSdkVersion globalConfiguration["androidCompileSdkVersion"]
-    buildToolsVersion globalConfiguration["androidBuildToolsVersion"]
 
     defaultConfig {
         minSdkVersion globalConfiguration["androidMinSdkVersion"]
@@ -52,11 +59,25 @@ android {
 
 kapt {
     correctErrorTypes = true
-}
 
+    javacOptions {
+        // Increase the max count of errors from annotation processors.
+        // Default is 100.
+        option("-Xmaxerrs", 500)
+    }
+}
 configurations.all {
     resolutionStrategy {
         force "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
+    }
+}
+
+allprojects {
+    afterEvaluate {
+        extensions.findByName('kapt')?.arguments {
+            arg("dagger.formatGeneratedSource", "disabled")
+            arg("dagger.gradle.incremental", "enabled")
+        }
     }
 }
 
@@ -64,7 +85,7 @@ dependencies {
     def mobileUiDependencies = rootProject.ext.mobileUiDependencies
     def mobileUiTestDependencies = rootProject.ext.mobileUiTestDependencies
 
-    implementation project(':presentation')
+    api project(':presentation')
     implementation project(':data')
     implementation project(':cache')
     implementation project(':remote')

--- a/mobile-ui/src/main/java/org/buffer/android/boilerplate/ui/injection/ApplicationComponent.kt
+++ b/mobile-ui/src/main/java/org/buffer/android/boilerplate/ui/injection/ApplicationComponent.kt
@@ -6,19 +6,18 @@ import dagger.Component
 import dagger.android.support.AndroidSupportInjectionModule
 import org.buffer.android.boilerplate.ui.BufferooApplication
 import org.buffer.android.boilerplate.ui.injection.module.*
-import org.buffer.injection.module.ApplicationModule
+import org.buffer.android.boilerplate.ui.injection.module.ApplicationModule
 import javax.inject.Singleton
 
 @Singleton
-@Component(modules = arrayOf(
-        ApplicationModule::class,
-        AndroidSupportInjectionModule::class,
-        CacheModule::class,
-        DataModule::class,
-        DomainModule::class,
-        PresentationModule::class,
-        RemoteModule::class,
-        UiModule::class)
+@Component(modules = [ApplicationModule::class,
+    AndroidSupportInjectionModule::class,
+    CacheModule::class,
+    DataModule::class,
+    DomainModule::class,
+    PresentationModule::class,
+    RemoteModule::class,
+    UiModule::class]
 )
 interface ApplicationComponent {
 

--- a/mobile-ui/src/main/java/org/buffer/android/boilerplate/ui/injection/module/ApplicationModule.kt
+++ b/mobile-ui/src/main/java/org/buffer/android/boilerplate/ui/injection/module/ApplicationModule.kt
@@ -1,4 +1,4 @@
-package org.buffer.injection.module
+package org.buffer.android.boilerplate.ui.injection.module
 
 import android.app.Application
 import android.content.Context

--- a/presentation/build.gradle
+++ b/presentation/build.gradle
@@ -68,5 +68,5 @@ dependencies {
     testImplementation presentationTestDependencies.robolectric
     testImplementation "android.arch.core:core-testing:1.0.0"
 
-    implementation project(':domain')
+    api project(':domain')
 }


### PR DESCRIPTION
Due to transitive dependencies, the `mobile-ui` layer using `implementation` but `api` should be added instead thus doesn't works.

This fix also include a few from this references:
1. [Dagger 2 Multi-Module](https://developer.android.com/training/dependency-injection/dagger-multi-module)
2. [Increase buffer for console output (annotation processor have a lot of output)](https://stackoverflow.com/a/39277199/3763032) & [Dagger 2 swallow outputs](https://github.com/google/dagger/issues/306)
3. [Wrong import package](https://github.com/google/dagger/issues/1227#issuecomment-559534129)
4. [Kotlin & Dagger 2 Gotchas part 1](https://medium.com/@naturalwarren/dagger-kotlin-3b03c8dd6e9b), [Part 2](https://medium.com/androiddevelopers/dagger-in-kotlin-gotchas-and-optimizations-7446d8dfd7dc) & [Part 3](https://github.com/google/dagger/issues/900)